### PR TITLE
Fix input_file for mplayer on Windows

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1984,8 +1984,9 @@ def launch_player(song, songdata, cmd):
         if "mplayer" in Config.PLAYER.get:
             cmd.append('-input')
             if mswin:
-                # Mplayer does not recognize path starting with drive letter
-                input_file = input_file[2:]
+                # Mplayer does not recognize path starting with drive letter,
+                # or with backslashes as a delimiter.
+                input_file = input_file[2:].replace('\\', '/')
             cmd.append('conf='+input_file)
             p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT, bufsize=1)

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1983,6 +1983,9 @@ def launch_player(song, songdata, cmd):
 
         if "mplayer" in Config.PLAYER.get:
             cmd.append('-input')
+            if mswin:
+                # Mplayer does not recognize path starting with drive letter
+                input_file = input_file[2:]
             cmd.append('conf='+input_file)
             p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT, bufsize=1)


### PR DESCRIPTION
Apparently mplayer cannot handle paths starting with a drive letter.