### PR TITLE
Replace spaces with hyphens in 'open' and 'view' commands

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2810,6 +2810,7 @@ def save_last():
 
 def open_save_view(action, name):
     """ Open, save or view a playlist by name.  Get closest name match. """
+    name = name.replace(" ", "-")
     if action == "open" or action == "view":
 
         saved = g.userpl.get(name)
@@ -2853,7 +2854,6 @@ def open_save_view(action, name):
             g.content = generate_songlist_display()
 
         else:
-            name = name.replace(" ", "-")
             g.userpl[name] = Playlist(name, list(g.model.songs))
             g.message = F('pl saved') % name
             save_to_file()


### PR DESCRIPTION
It makes sense for open and view to behave the same way as save in this regard.