### PR TITLE
Add mpv_input_conf and mplayer_input_conf settings

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1995,6 +1995,8 @@ def launch_player(song, songdata, cmd):
         key = i.split()[0]
         if key not in bound_keys:
             conf += i
+
+    sockpath = None
     try:
         with tempfile.NamedTemporaryFile('w', prefix='mpsyt-input',
                                          delete=False) as tmpfile:
@@ -2017,7 +2019,6 @@ def launch_player(song, songdata, cmd):
 
         elif "mpv" in Config.PLAYER.get:
             cmd.append('--input-conf=' + input_file)
-            sockpath = None
 
             if g.mpv_usesock:
                 sockpath = tempfile.mktemp('.sock', 'mpsyt-mpv')

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1983,12 +1983,13 @@ def launch_player(song, songdata, cmd):
     if confpath:
         with open(confpath) as conffile:
             conf = conffile.read() + '\n'
+    conf = conf.replace("quit", "quit 43")
     conf = conf.replace("playlist_prev", "quit 42")
     conf = conf.replace("pt_step -1", "quit 42")
-    conf = conf.replace("playlist_next", "quit 43")
-    conf = conf.replace("pt_step 1", "quit 43")
-    standard_cmds = ['> quit 43\n', '< quit 42\n', 'NEXT quit 43\n',
-                     'PREV quit 42\n', 'ENTER quit 43\n']
+    conf = conf.replace("playlist_next", "quit")
+    conf = conf.replace("pt_step 1", "quit")
+    standard_cmds = ['q quit 43\n', '> quit\n', '< quit 42\n', 'NEXT quit\n',
+                     'PREV quit 42\n', 'ENTER quit\n']
     bound_keys = [i.split()[0] for i in conf.splitlines() if i.split()]
     for i in standard_cmds:
         key = i.split()[0]
@@ -3150,7 +3151,7 @@ def play_range(songlist, shuffle=False, repeat=False, override=False):
         if returncode == 42:
             n -= 1
 
-        elif returncode == 0:
+        elif returncode == 43:
             break
 
         else:

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1981,8 +1981,8 @@ def launch_player(song, songdata, cmd):
         confpath = Config.MPV_INPUT_CONF.get
     conf = ''
     if confpath:
-        with open(confpath) as file:
-            conf = file.read() + '\n'
+        with open(confpath) as conffile:
+            conf = conffile.read() + '\n'
     conf = conf.replace("playlist_prev", "quit 42")
     conf = conf.replace("pt_step -1", "quit 42")
     conf = conf.replace("playlist_next", "quit 43")
@@ -3150,11 +3150,11 @@ def play_range(songlist, shuffle=False, repeat=False, override=False):
         if returncode == 42:
             n -= 1
 
-        elif returncode in (43, None):
-            n += 1
+        elif returncode == 0:
+            break
 
         else:
-            break
+            n += 1
 
         if n == -1:
             n = len(songlist) - 1 if repeat else 0

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2038,6 +2038,7 @@ def launch_player(song, songdata, cmd):
         else:
             with open(os.devnull, "w") as devnull:
                 returncode = subprocess.call(cmd, stderr=devnull)
+            p = None
 
         return returncode
 
@@ -2046,16 +2047,13 @@ def launch_player(song, songdata, cmd):
         return None
 
     finally:
-        try:
-            os.unlink(input_file)
+        os.unlink(input_file)
 
-            if sockpath:
-                os.unlink(sockpath)
+        if sockpath:
+            os.unlink(sockpath)
 
+        if p and p.poll() is None:
             p.terminate()  # make sure to kill mplayer if mpsyt crashes
-
-        except (OSError, AttributeError, UnboundLocalError):
-            pass
 
 
 def player_status(po_obj, prefix, songlength=0, mpv=False, sockpath=None):


### PR DESCRIPTION
This is my solution to issue #178. With this, the user can have a custom input.conf.  The commands for going to the next and previous track are replaced with the quit commands that communicate that to mpsyt.

In addition, the defaults are changed to be the same as mpv/mplayer.  If users want to go through their playlist with j/k, they can set mpv_input_conf/mplayer_input_conf to an input.conf that does that.