### PR TITLE
Support py2exe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,7 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
     ],
     long_description=open("README.rst").read(),
-    options={"py2exe": {"excludes": "readline, win32api, win32con"}}
+    options={"py2exe": {"excludes": "readline, win32api, win32con, xerox",
+	                "bundle_files": 1}},
+    zipfile=None
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,12 @@ try:
 except ImportError:
     from distutils.core import setup
 
+try:
+    import py2exe # Add py2exe command
+
+except ImportError:
+    pass
+
 setup(
     name="mps-youtube",
     version="0.2.1",
@@ -24,6 +30,7 @@ setup(
     download_url="https://github.com/np1/mps-youtube/tarball/master",
     packages=['mps_youtube'],
     entry_points=dict(console_scripts=['mpsyt = mps_youtube:main.main']),
+    console=['mpsyt'],
     install_requires=['Pafy >= 0.3.66'],
     package_data={"": ["LICENSE", "README.rst", "CHANGELOG"]},
     classifiers=[
@@ -52,5 +59,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
     ],
-    long_description=open("README.rst").read()
+    long_description=open("README.rst").read(),
+    options={"py2exe": {"excludes": "readline, win32api, win32con"}}
 )


### PR DESCRIPTION
This is a solution to Issue #121.  It seems to work, but will probably need more testing.  Run `python setup.py py2exe` to create a "dist" folder with mpsyt.exe and it's dependencies.

Edit: This requires py2exe of course.  Just run `pip install py2exe` to install that.