### PR TITLE
Add FreeBSD to the list of known operating systems

### DIFF
--- a/mps_youtube/terminalsize.py
+++ b/mps_youtube/terminalsize.py
@@ -29,7 +29,7 @@ def get_terminal_size():
             tuple_xy = _get_terminal_size_tput()
             # needed for window's python in cygwin's xterm!
 
-    if current_os in ['Linux', 'Darwin'] or current_os.startswith('CYGWIN'):
+    if current_os in ['Darwin', 'FreeBSD', 'Linux'] or current_os.startswith('CYGWIN'):
         tuple_xy = _get_terminal_size_linux()
 
     if tuple_xy is None:


### PR DESCRIPTION
mps-youtube does not run on FreeBSD because it is not listed in the supported operating system. It fails with the following error:

    ➜  ~  env SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt mpsyt
    Traceback (most recent call last):
      File "/usr/local/bin/mpsyt", line 9, in <module>
        load_entry_point('mps-youtube==0.2.1', 'console_scripts', 'mpsyt')()
      File "/usr/local/lib/python2.7/site-packages/mps_youtube/main.py", line 4166, in main
        g.content = logo(col=c.g, version=__version__) + "\n\n"
      File "/usr/local/lib/python2.7/site-packages/mps_youtube/main.py", line 1393, in logo
        x, y, _ = getxy()
      File "/usr/local/lib/python2.7/site-packages/mps_youtube/main.py", line 121, in getxy
        max_results = y - 4 if y < 54 else 50
    TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
