### PR TITLE
Fix test of None value in tuple_xy value

### DIFF
--- a/mps_youtube/terminalsize.py
+++ b/mps_youtube/terminalsize.py
@@ -25,14 +25,14 @@ def get_terminal_size():
     if current_os == 'Windows':
         tuple_xy = _get_terminal_size_windows()
 
-        if tuple_xy is None:
+        if not all(tuple_xy):
             tuple_xy = _get_terminal_size_tput()
             # needed for window's python in cygwin's xterm!
 
     if current_os in ['Linux', 'Darwin'] or current_os.startswith('CYGWIN'):
         tuple_xy = _get_terminal_size_linux()
 
-    if tuple_xy is None:
+    if not all(tuple_xy):
         tuple_xy = (80, 25)      # default value
 
     return tuple_xy


### PR DESCRIPTION
The function `get_terminal_size()` does not assign a default value, because the test on the variable tuple_xy always fails.
Use `all()` builtin function to fix it.