### PR TITLE
Fix race condition in mpv 0.7+ code

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2054,11 +2054,20 @@ def player_status(po_obj, prefix, songlength=0, mpv=False, sockpath=None):
     volume_level = None
 
     if sockpath:
-        time.sleep(1)
+        s = socket.socket(socket.AF_UNIX)
+
+        tries = 0
+        while tries < 10:
+            time.sleep(.5)
+            try:
+                s.connect(sockpath)
+                break
+            except socket.error:
+                pass
+        else:
+            return
 
         try:
-            s = socket.socket(socket.AF_UNIX)
-            s.connect(sockpath)
             cmd = {"command": ["observe_property", 1, "time-pos"]}
             s.send(json.dumps(cmd).encode() + b'\n')
             cmd = {"command": ["observe_property", 2, "volume"]}

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2057,15 +2057,13 @@ def player_status(po_obj, prefix, songlength=0, mpv=False, sockpath=None):
         s = socket.socket(socket.AF_UNIX)
 
         tries = 0
-        while tries < 10:
+        while tries < 10 and po_obj.poll() is None:
             time.sleep(.5)
             try:
                 s.connect(sockpath)
                 break
             except socket.error:
                 pass
-            if po_obj.poll() is not None: # Process not running
-                return
             tries += 1
         else:
             return

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2064,6 +2064,9 @@ def player_status(po_obj, prefix, songlength=0, mpv=False, sockpath=None):
                 break
             except socket.error:
                 pass
+            if po_obj.poll() is not None: # Process not running
+                return
+            tries += 1
         else:
             return
 


### PR DESCRIPTION
I have noticed that occasionally the progress bar would not show up.  My interpretation is that mpv sometimes takes longer that the one second wait to set up the socket, and thus an error was raised, exiting player_status.  The player would keep playing, due to the `p.wait()` statement.  If I am correct, this should solve the problem.

I do not know if there is a better way to do this.