### PR TITLE
Install desktop file on first run on Ubuntu systems

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -852,6 +852,7 @@ def init():
     init_readline()
     init_cache()
     init_transcode()
+    init_ubuntu_desktop_file()
 
     # set player to mpv or mplayer if found, otherwise unset
     suffix = ".exe" if mswin else ""
@@ -1026,6 +1027,23 @@ def init_cache():
             dbg(c.r + "Cache file failed to open" + c.w)
 
         prune_streams()
+
+
+def init_ubuntu_desktop_file():
+    """ Install desktop file if Ubuntu to get MPRIS working. """
+    if "Ubuntu" in platform.platform():
+        homedir = os.path.expanduser("~")
+        appdir = ".local/share/applications"
+        appdir = os.path.join(homedir, appdir)
+        filename = "mps-youtube.desktop"
+
+        if not os.path.exists(os.path.join(appdir, filename)):
+            dbg("no desktop file in local appdir")
+
+            if has_exefile("desktop-file-install"):
+                dbg("has desktop-file-install executable")
+                from mps_youtube import ubuntu
+                ubuntu.install_desktop_file(get_config_dir(), appdir)
 
 
 def init_readline():

--- a/mps_youtube/ubuntu.py
+++ b/mps_youtube/ubuntu.py
@@ -1,0 +1,35 @@
+"""
+ubuntu.py - install ubuntu desktop file, needed for mpris.
+
+https://github.com/np1/mps-youtube
+"""
+
+import os
+import subprocess
+
+desktop_file_contents = """\
+[Desktop Entry]
+Name=mps-youtube
+GenericName=Music Player
+Keywords=Audio;Song;Podcast;Playlist;youtube.com;
+Exec=mpsyt %U
+Terminal=true
+Icon=terminal
+Type=Application
+Categories=AudioVideo;Audio;Player;
+StartupNotify=true"""
+
+
+def install_desktop_file(configdir, local_app_dir):
+    """ Install desktop file if it hasn't already been done. """
+    if not os.path.exists(local_app_dir):
+        os.makedirs(local_app_dir)
+
+    fname = "/tmp/mps-youtube.desktop"
+
+    with open(fname, "w") as dtf:
+        dtf.write(desktop_file_contents)
+
+    cmd = ["desktop-file-install", "--dir={}".format(local_app_dir), fname]
+    subprocess.call(cmd)
+    os.unlink(fname)

--- a/mps_youtube/ubuntu.py
+++ b/mps_youtube/ubuntu.py
@@ -21,7 +21,7 @@ StartupNotify=true"""
 
 
 def install_desktop_file(configdir, local_app_dir):
-    """ Install desktop file if it hasn't already been done. """
+    """ Install desktop file. """
     if not os.path.exists(local_app_dir):
         os.makedirs(local_app_dir)
 


### PR DESCRIPTION
This installs the `mps-youtube.desktop` file needed to get the MPRIS interface working in Ubuntu / Xubuntu sound indicator. It gets installed automatically when running mpsyt and put in `~/.local/share/applications` so doesn't need sudo.