### PR TITLE
Do not test mpv version during initialization 

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -877,7 +877,6 @@ def init():
     # check mpv version
 
     if "mpv" in Config.PLAYER.get:
-        g.mpv_version = get_mpv_version(Config.PLAYER.get)
         options = utf8_decode(subprocess.check_output(
             [Config.PLAYER.get, "--list-options"]))
         # g.mpv_usesock = "--input-unix-socket" in options and not mswin

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -876,12 +876,12 @@ def init():
 
     # check mpv version
 
-    if "mpv" in Config.PLAYER.get:
+    if "mpv" in Config.PLAYER.get and not mswin:
         options = utf8_decode(subprocess.check_output(
             [Config.PLAYER.get, "--list-options"]))
         # g.mpv_usesock = "--input-unix-socket" in options and not mswin
 
-        if "--input-unix-socket" in options and not mswin:
+        if "--input-unix-socket" in options:
             g.mpv_usesock = True
             dbg(c.g + "mpv supports --input-unix-socket" + c.w)
 


### PR DESCRIPTION
This fixes one problem from issue #223, but mpv should probably also default to `mpv.com` rather that `.exe` on Windows (I don't know if that is the case for all versions of mpv), and the op also seems to have an issue with how the progress bar is displaying.