### PR TITLE
Remove double-quotes from filename if any.

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2710,6 +2710,7 @@ def _make_fname(song, ext=None, av=None, subdir=None):
     # filename = song.title[:59] + "." + extension
     filename = song.title + "." + extension
     filename = os.path.join(ddir, mswinfn(filename.replace("/", "-")))
+    filename = filename.replace('"', '')
     return filename
 
 


### PR DESCRIPTION
Having double-quotes in filename makes it difficult to play(manually) in
terminal using cli players like 'mplayer'. Better remove the quotes
before saving the file.

Example:
- "Caught in the Rain" - Shankar Tucker ft. Rohan Kymal