### PR TITLE
fix landscape bot

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -20,6 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
+# python2 compatibility (for landscape)
+from __future__ import print_function
+
 __version__ = "0.2.5-dev"
 __notes__ = "development version"
 __author__ = "np1"


### PR DESCRIPTION
Adds compatibility import to help landscape parse `main.py`. This import should do no harm with python 3, it just does nothing.