### PR TITLE
More applicable pagination method than the current.

### DIFF
--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -4093,10 +4093,11 @@ def add_rm_all(action):
         songlist_rm_add("add", "-" + str(size))
 
 
-def nextprev(np):
+def nextprev(np, page=None):
     """ Get next / previous search results. """
     glsq = g.last_search_query
     content = g.model.songs
+    max_results = getxy().max_results
 
     if "user" in g.last_search_query:
         function, query = usersearch_id, glsq['user']
@@ -4117,7 +4118,6 @@ def nextprev(np):
     good = False
 
     if np == "n":
-        max_results = getxy().max_results
         if len(content) == max_results and glsq:
             if (g.current_page + 1) * max_results < 500:
                 if g.more_pages:
@@ -4125,12 +4125,17 @@ def nextprev(np):
                     good = True
 
     elif np == "p":
-        if g.current_page > 0 and g.last_search_query:
+
+        if page and int(page) in range(1,20):
+            g.current_page = int(page)-1
+            good = True
+
+        elif g.current_page > 0 and g.last_search_query:
             g.current_page -= 1
             good = True
 
     if good:
-        function(query, g.current_page, splash=True)
+        function(query, page=g.current_page, splash=True)
         g.message += " : page {}".format(g.current_page + 1)
 
     else:
@@ -4799,7 +4804,7 @@ def main():
         download: r'(dv|da|d|dl|download)\s*(\d{1,4})$',
         play_url: r'playurl\s(.*[-_a-zA-Z0-9]{11}[^\s]*)(\s-(?:f|a|w))?$',
         comments: r'c\s?(\d{1,4})$',
-        nextprev: r'(n|p)$',
+        nextprev: r'(n|p)\s*(\d{1,2})?$',
         play_all: r'(%s{0,3})(?:\*|all)\s*(%s{0,3})$' % (rs, rs),
         user_pls: r'u(?:ser)?pl\s(.*)$',
         save_last: r'save\s*$',
@@ -4920,6 +4925,7 @@ Then, when results are shown:
 {2}//<query>{1} or {2}..<query>{1} - search for YouTube playlists. e.g., \
 {2}//80's music{1}
 {2}n{1} and {2}p{1} - continue search to next/previous pages.
+{2}p <number>{1} - switch to page <number>.
 
 {2}album <album title>{1} - Search for matching tracks using album title
 {2}user <username>{1} - list YouTube uploads by <username>.

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1616,7 +1616,7 @@ def call_gdata(api, qs):
     qs = qs.copy()
     qs['key'] = Config.API_KEY.get
     url = "https://www.googleapis.com/youtube/v3/" + api + '?' + urlencode(qs)
-    
+
     if url in g.url_memo:
         return json.loads(g.url_memo[url])
 
@@ -1760,13 +1760,16 @@ def screen_update(fill_blank=True):
     if g.content:
         xprint(g.content)
 
-    if g.message:
-        xprint(g.message)
+    if g.message or g.rprompt:
+        out = g.message or ''
+        blanks = getxy().width - len(out) - len(g.rprompt or '')
+        out += ' ' * blanks + (g.rprompt or '')
+        xprint(out)
 
     elif fill_blank:
         xprint("")
 
-    g.message = g.content = False
+    g.message = g.content = g.rprompt = False
 
 
 def playback_progress(idx, allsongs, repeat=False):
@@ -1899,6 +1902,7 @@ def generate_playlist_display():
     if not g.ytpls:
         g.message = c.r + "No playlists found!"
         return logo(c.g) + "\n\n"
+    g.rprompt = page_msg(g.current_page)
 
     cw = getxy().width
     fmtrow = "%s%-5s %s %-12s %-8s  %-2s%s\n"
@@ -1980,6 +1984,7 @@ def generate_songlist_display(song=False, zeromsg=None, frmat="search"):
     if not songs:
         g.message = zeromsg or "Enter /search-term to search or [h]elp"
         return logo(c.g) + "\n\n"
+    g.rprompt = page_msg(g.current_page)
 
     have_meta = all(x.ytid in g.meta for x in songs)
     user_columns = get_user_columns() if have_meta else []

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -4128,13 +4128,14 @@ def nextprev(np, page=None):
 
     elif np == "p":
 
-        if page and int(page) in range(1,20):
-            g.current_page = int(page)-1
-            good = True
+        if g.last_search_query:
+            if page and int(page) in range(1,20):
+                g.current_page = int(page)-1
+                good = True
 
-        elif g.current_page > 0 and g.last_search_query:
-            g.current_page -= 1
-            good = True
+            elif g.current_page > 0:
+                g.current_page -= 1
+                good = True
 
     if good:
         function(query, page=g.current_page, splash=True)

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -4396,7 +4396,7 @@ def plist(parturl, page=0, splash=True, dumps=False):
     g.last_search_query = {"playlist": parturl}
     g.browse_mode = "normal"
     g.ytpl = dict(name=ytpl_title, items=songs)
-    g.current_page = page
+    g.current_page = 0
     g.model.songs = songs[:max_results]
     # preload first result url
     kwa = {"song": songs[0], "delay": 0}

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1962,7 +1962,7 @@ def get_user_columns():
 def page_msg(page=0):
     """ Format information about currently displayed page to a string. """
     max_results = getxy().max_results
-    page_count = max(int(min(g.result_count, 500)/max_results) + 1, 1)
+    page_count = max(int(math.ceil(min(g.result_count, 500)/max_results)), 1)
     if page_count > 1:
         pagemsg = "{}{}/{}{}"
         #start_index = max_results * g.current_page
@@ -4387,7 +4387,10 @@ def plist(parturl, page=0, splash=True, dumps=False):
     g.pafy_pls[parturl] = yt_playlist
     ytpl_items = yt_playlist['items']
     ytpl_title = yt_playlist['title']
+    g.result_count = len(ytpl_items)
+    g.more_pages = max_results < len(ytpl_items)
     g.content = generate_songlist_display()
+
     songs = []
 
     for item in ytpl_items:

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1968,7 +1968,8 @@ def page_msg(page=0):
         return pagemsg.format('<' if page > 0 else '[',
                               "%s%s%s" % (c.y, page+1, c.w),
                               page_count,
-                              ']>'[int(g.more_pages or (page < page_count))])
+                              ']>'[int(g.more_pages != None or
+                                       (page < page_count))])
     return None
 
 

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -1653,7 +1653,7 @@ def get_page_info_from_json(jsons, result_count=None):
     g.result_count = pageinfo.get('totalResults')
     if result_count: # limit number of results, e.g. if api makes it up
         if result_count < per_page:
-          g.result_count = min(g.result_count, result_count)
+            g.result_count = min(g.result_count, result_count)
 
 
 def get_tracks_from_json(jsons):
@@ -1968,8 +1968,7 @@ def page_msg(page=0):
         return pagemsg.format('<' if page > 0 else '[',
                               "%s%s%s" % (c.y, page+1, c.w),
                               page_count,
-                              '>' if g.more_pages
-                              or page < page_count else ']')
+                              ']>'[int(g.more_pages or (page < page_count))])
     return None
 
 
@@ -2783,10 +2782,11 @@ def pl_search(term, page=0, splash=True, is_user=False):
         is_user = term["is_user"]
         term = term["term"]
 
-    g.content = logo(c.g)
-    prog = "user: " + term if is_user else term
-    g.message = "Searching playlists for %s" % c.y + prog + c.w
-    screen_update()
+    if splash:
+        g.content = logo(c.g)
+        prog = "user: " + term if is_user else term
+        g.message = "Searching playlists for %s" % c.y + prog + c.w
+        screen_update()
 
     if is_user:
         ret = channelfromname(term)
@@ -4640,8 +4640,10 @@ def search_album(term, page=0, splash=True):
     out += ("[Enter] to continue, [q] to abort, or enter artist name for:\n"
             "    %s" % (c.y + term + c.w + "\n"))
 
-    g.message, g.content = out, logo(c.b)
-    screen_update()
+    if splash:
+        g.message, g.content = out, logo(c.b)
+        screen_update()
+
     prompt = "Artist? [%s] > " % album['artist']
     xprint(prompt, end="")
     artistentry = input().strip()

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -2556,7 +2556,7 @@ def _search(progtext, qs=None, splash=True, pre_load=True):
 
 def token(page):
     """ Returns a page token for a given start index. """
-    index = page * getxy().max_results
+    index = (page or 0) * getxy().max_results
     k = 0
     while index > 255:
         index -= 128
@@ -4535,7 +4535,7 @@ def _match_tracks(artist, title, mb_tracks):
                                                dtime(length)))
         q = "%s %s" % (artist, ttitle)
         w = q = ttitle if artist == "Various Artists" else q
-        query = generate_search_qs(w, None, result_count=50)
+        query = generate_search_qs(w, 0, result_count=50)
         dbg(query)
         have_results = _search(q, query, splash=False, pre_load=False)
 

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -781,6 +781,7 @@ class g(object):
     last_search_query = {}
     current_page = 0
     result_count = 0
+    more_pages = None
     rprompt = None
     active = Playlist(name="active")
     text = {}


### PR DESCRIPTION
Gets rid of the current workaround for search result pagination and **returns to the more stable and useful method of using a numerical value to address a page**. This unitizes the way page navigation is handled by methods that use different APIs should give us back the functionality mpsyt used to have before gdata2 shutdown.
Changes that make this happen:
  * going back to numeric global `g.current_page`
  * rather than collecting page tokens, generate them ourselves for any position in result list we want. [ab57955e925553ba152e10cec408842ba2ac686d]
  * instead of collecting page tokens in server responses, extract more userful information like result count. [744f4c3c832663f80dbdbee0f85ea55516662462]

As a bonus, I already added a nice little page number field to the status line that shows whenever there is more than just one page of results [d7fdd83f604404c11d66cbd9384ee16c1dc71da9], and also an optional argument to the `p` command, which can now be used to change directly to a specified page [0ff7c9e1e931f70aad02d7038d94b8913263c60f].




