### PR TITLE
Reworked desktop file install

### DIFF
--- a/install/linux/usr/share/applications/mps-youtube.desktop
+++ b/install/linux/usr/share/applications/mps-youtube.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=mps-youtube
+GenericName=Music Player
+Keywords=Audio;Song;Podcast;Playlist;youtube.com;
+Exec=mpsyt %U
+Terminal=true
+Icon=terminal
+Type=Application
+Categories=AudioVideo;Audio;Player;
+StartupNotify=true
+NoDisplay=true

--- a/mps_youtube/main.py
+++ b/mps_youtube/main.py
@@ -873,7 +873,6 @@ def init():
     init_readline()
     init_cache()
     init_transcode()
-    init_desktop_file()
 
     # set player to mpv or mplayer if found, otherwise unset
     suffix = ".exe" if mswin else ""
@@ -1061,46 +1060,6 @@ def init_cache():
             dbg(c.r + "Cache file failed to open" + c.w)
 
         prune_streams()
-
-
-def init_desktop_file():
-    """ Install desktop file. """
-    # Required for mpris on Ubuntu
-    if mswin:
-        return
-    appdir = os.path.expanduser("~/.local/share/applications")
-    filename = "mps-youtube.desktop"
-
-    if not os.path.exists(os.path.join(appdir, filename)):
-        dbg("no desktop file in local appdir")
-
-        if has_exefile("desktop-file-install"):
-            dbg("has desktop-file-install executable")
-
-            if not os.path.exists(appdir):
-                os.makedirs(appdir)
-
-            fname = os.path.join(tempfile.gettempdir(), "mps-youtube.desktop")
-
-            desktop_file_contents = \
-                "[Desktop Entry]\n" \
-                "Name=mps-youtube\n" \
-                "GenericName=Music Player\n" \
-                "Keywords=Audio;Song;Podcast;Playlist;youtube.com;\n" \
-                "Exec=mpsyt %U\n" \
-                "Terminal=true\n" \
-                "Icon=terminal\n" \
-                "Type=Application\n" \
-                "Categories=AudioVideo;Audio;Player;\n" \
-                "StartupNotify=true\n" \
-                "NoDisplay=true"
-
-            with open(fname, "w") as dtf:
-                dtf.write(desktop_file_contents)
-
-            cmd = ["desktop-file-install", "--dir={}".format(appdir), fname]
-            subprocess.call(cmd)
-            os.unlink(fname)
 
 
 def init_readline():

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ python setup.py sdist bdist_wheel
 """
 
 from setuptools import setup
+import sys
 
 options = dict(
     name="mps-youtube",
@@ -54,6 +55,12 @@ options = dict(
                        "bundle_files": 1}},
     long_description=open("README.rst").read()
 )
+
+if sys.platform.startswith('linux'):
+    # Install desktop file. Required for mpris on Ubuntu
+    options['data_files'] = [
+        ('share/applications/',
+            ['install/linux/usr/share/applications/mps-youtube.desktop'])]
 
 try:
     import py2exe


### PR DESCRIPTION
Current version doesn't remove desktop file on uninstall. Also checking in runtime seems to be a bit hack.

This version uses setup tools to install desktop file where appropriate (it will be installed system-wide, instead of user directory).

Tested on ubuntu 14.04 with `pip3 install https://github.com/hrnr/mps-youtube/archive/desktop-file.zip --upgrade`. MPRIS is immediately functional after that.