### PR TITLE
Fixed linux installation bug (py2exe related)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,13 @@ options = dict(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
     ],
-    options={"py2exe": {"excludes": "readline, win32api, win32con, xerox, "
-	                            "dbus, gi, urllib.unquote_plus, "
-				    "urllib.urlencode",
-                       "bundle_files": 1}},
+    options={
+        "py2exe": {
+            "excludes": ("readline, win32api, win32con, xerox, dbus, gi,"
+                         " urllib.unquote_plus, urllib.urlencode"),
+            "bundle_files": 1
+        }
+    },
     long_description=open("README.rst").read()
 )
 
@@ -65,7 +68,8 @@ try:
     # in easy_install
     options['console'] = ['mpsyt']
     options['zipfile'] = None
-except ImportError:
+except (ImportError, NameError):
+    # importing py2exe can also throw a NameError in some linux environments.
     pass
 
 setup(**options)


### PR DESCRIPTION
Also cleaned up tab/whitespace issues in setup.py

Setup.py is now pep-8 compliant.

Previously, this error was being thrown after importing py2exe:

File "/usr/local/lib/python3.4/dist-packages/py2exe/_wapi.py", line 4, in
<module>

      _kernel32 = WinDLL("kernel32")

      NameError: name 'WinDLL' is not defined

This happened on my Ubuntu 14.04 LTS system.